### PR TITLE
Add post-upload file size verification to Upload method

### DIFF
--- a/src/kickflip/Services/SftpDeploymentService.cs
+++ b/src/kickflip/Services/SftpDeploymentService.cs
@@ -86,6 +86,12 @@ public class SftpDeploymentService
          
             CreateDirectoriesRecursively(directoryPath);
             _client.UploadFile(fileStream, remotePath);
+
+            var remoteFileInfo = _client.GetAttributes(remotePath);
+            if (remoteFileInfo.Size != fileInfo.Length)
+            {
+                throw new Exception($"Post-upload check failed: Local file size ({fileInfo.Length} bytes) does not match remote file size ({remoteFileInfo.Size} bytes).");
+            }
             
             Console.WriteLine($"Uploaded {uploadOutput}");
             return true;


### PR DESCRIPTION
Modified the Upload method in the SftpDeploymentService class to include a post-upload verification step that checks if the size of the local file matches the size of the remote file after uploading. This ensures the integrity of the file transfer by comparing the file sizes in bytes. If the file sizes do not match, an exception is thrown, indicating a possible issue with the file transfer process. This enhancement aims to improve the reliability of the deployment process by ensuring that files are correctly uploaded to the remote server.